### PR TITLE
Fix StringQuantum get values

### DIFF
--- a/Sources/Typesense/Shared/Coders.swift
+++ b/Sources/Typesense/Shared/Coders.swift
@@ -5,6 +5,16 @@ public let decoder = JSONDecoder()
 
 public enum StringQuantum: Codable {
     
+    public var arrStr : [String]? {
+        guard case .arrOfStrings(let arrOfStrings) = self else { return nil }
+        return arrOfStrings
+    }
+    
+    public var arrArrStr : [[String]]? {
+        guard case .arrOfArrOfStrings(let arrOfArrOfStrings) = self else { return nil }
+        return arrOfArrOfStrings
+    }
+
     case arrOfStrings([String]), arrOfArrOfStrings([[String]])
     
     public init(from decoder: Decoder) throws {


### PR DESCRIPTION
Add provision to get values of `MatchedTokens` from the `StringQuantum` enum. To access them, please use:

- `yourStringQuantum.arrStr` to get a an array of strings type of matched tokens.
- `yourStringQuantum.arrArrStr` to get a an array of array of strings type of matched tokens.
