### PR TITLE
Allow search and multi-search to return raw data

### DIFF
--- a/Sources/Typesense/Documents.swift
+++ b/Sources/Typesense/Documents.swift
@@ -51,7 +51,7 @@ public struct Documents {
         
     }
     
-    public func search<T>(_ searchParameters: SearchParameters, for: T.Type) async throws -> (SearchResult<T>?, URLResponse?) {
+    public func search(_ searchParameters: SearchParameters) async throws -> (Data?, URLResponse?) {
         var searchQueryParams: [URLQueryItem] =
         [
             URLQueryItem(name: "q", value: searchParameters.q),
@@ -251,7 +251,11 @@ public struct Documents {
             searchQueryParams.append(URLQueryItem(name: "remote_embedding_num_tries", value: String(remoteEmbeddingNumTries)))
         }
 
-        let (data, response) = try await apiCall.get(endPoint: "\(RESOURCEPATH)/search", queryParameters: searchQueryParams)
+        return try await apiCall.get(endPoint: "\(RESOURCEPATH)/search", queryParameters: searchQueryParams)
+    }
+    
+    public func search<T>(_ searchParameters: SearchParameters, for: T.Type) async throws -> (SearchResult<T>?, URLResponse?) {
+        let (data, response) = try await search(searchParameters)
 
         if let validData = data {
             let searchRes = try decoder.decode(SearchResult<T>.self, from: validData)

--- a/Sources/Typesense/MultiSearch.swift
+++ b/Sources/Typesense/MultiSearch.swift
@@ -8,7 +8,7 @@ public struct MultiSearch {
         apiCall = ApiCall(config: config)
     }
     
-    public func perform<T>(searchRequests: [MultiSearchCollectionParameters], commonParameters: MultiSearchParameters, for: T.Type) async throws -> (MultiSearchResult<T>?, URLResponse?) {
+    public func perform(searchRequests: [MultiSearchCollectionParameters], commonParameters: MultiSearchParameters) async throws -> (Data?, URLResponse?) {
         var searchQueryParams: [URLQueryItem] = []
         
         if let query = commonParameters.q {
@@ -202,7 +202,11 @@ public struct MultiSearch {
         
         let searchesData = try encoder.encode(searches)
 
-        let (data, response) = try await apiCall.post(endPoint: "\(RESOURCEPATH)", body: searchesData, queryParameters: searchQueryParams)
+        return try await apiCall.post(endPoint: "\(RESOURCEPATH)", body: searchesData, queryParameters: searchQueryParams)
+    }
+    
+    public func perform<T>(searchRequests: [MultiSearchCollectionParameters], commonParameters: MultiSearchParameters, for: T.Type) async throws -> (MultiSearchResult<T>?, URLResponse?) {
+        let (data, response) = try await perform(searchRequests: searchRequests, commonParameters: commonParameters)
 
         if let validData = data {
             let searchRes = try decoder.decode(MultiSearchResult<T>.self, from: validData)


### PR DESCRIPTION
## Change Summary
Overriden 2 function:

- `Documents.search()`
- `MultiSearch.perform()`

## Why make this change
Currently the above 2 function will take a Codable type `T` and then try to decode it immediately after retrieving the data. This is not ideal because we lose the opportunities to implement a custom data parsing logic to it. E.g.

- `Documents.search()`: This function uses the default JSON decoder to decode the data. But sometimes we want to use other decoders, such as Firestore Decoder.
- `MultiSearch.perform()`: This function only takes 1 type of Codable, which is not ideal. E.g. for a social media app, when searching a post, we want to have some search suggestions. They are different types of data and the function won't be able to decode the multi search result.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
