### PR TITLE
fix: type `conversationHistory` should be an array & integer parameters incorrectly converted to boolean

### DIFF
--- a/Sources/Typesense/Models/SearchResultConversation.swift
+++ b/Sources/Typesense/Models/SearchResultConversation.swift
@@ -12,11 +12,11 @@ import Foundation
 public struct SearchResultConversation: Codable {
 
     public var answer: String
-    public var conversationHistory: [String: String]
+    public var conversationHistory: [[String: String]]
     public var conversationId: String
     public var query: String
 
-    public init(answer: String, conversationHistory: [String: String], conversationId: String, query: String) {
+    public init(answer: String, conversationHistory: [[String: String]], conversationId: String, query: String) {
         self.answer = answer
         self.conversationHistory = conversationHistory
         self.conversationId = conversationId

--- a/Sources/Typesense/utils/CreateURLQueryParams.swift
+++ b/Sources/Typesense/utils/CreateURLQueryParams.swift
@@ -21,7 +21,7 @@ func createURLQuery<T: Codable>(forSchema: T?) throws -> [URLQueryItem]{
         var stringVal = ""
         if let str = val as? String {
             stringVal = str
-        } else if let bool = val as? Bool {
+        } else if type(of: val) == type(of: NSNumber(booleanLiteral: true)) || type(of: val) == type(of: NSNumber(booleanLiteral: false)), let bool = val as? Bool{
             stringVal = String(bool)
         } else if let int = val as? Int {
             stringVal = String(int)

--- a/Tests/TypesenseTests/ConversationModelTests.swift
+++ b/Tests/TypesenseTests/ConversationModelTests.swift
@@ -78,4 +78,38 @@ final class ConversationModelTests: XCTestCase {
         }
     }
 
+    func testConversationSearch() async {
+        do {
+            let string = """
+            {
+            "conversation": {
+                "answer": " context information, I' unable to suggest an is information given about specific context action as,, specific titles If a preference for particular genre length of, please that information and I' try my best to suggestions.",
+                "conversation_history": [
+                {
+                    "user": "can you suggest an action series"
+                },
+                {
+                    "assistant": " context information, I' unable to suggest an is information given about specific context action as,, specific titles If a preference for particular genre length of, please that information and I' try my best to suggestions."
+                }
+                ],
+                "conversation_id": "123",
+                "query": "can you suggest an action series"
+            },
+            "results": [
+                {
+                "code": 404,
+                "error": "Not found."
+                }
+            ]
+            }
+            """
+            let data = string.data(using: .utf8)!
+            let _ = try decoder.decode(MultiSearchResult<Never>.self, from: data)
+            XCTAssertTrue(true)
+        }catch (let error) {
+            print(error)
+            XCTAssertTrue(false)
+        }
+    }
+
 }

--- a/Tests/TypesenseTests/CreateURLQueryParamsTests.swift
+++ b/Tests/TypesenseTests/CreateURLQueryParamsTests.swift
@@ -6,18 +6,24 @@ final class CreateURLQueryParamsTests: XCTestCase {
         var name = "Fast"
         var age: Int = 20
         var price: Int64 = 2000
+        var page: Int? = 1
+        var groupLimit: Int64? = 0
         var speed: Double = 120.555
         var mileage: Float = 120.5
         var isElectric = true
+        var inStock: Bool = false
         var empty: String? = nil
 
         enum CodingKeys: String, CodingKey {
             case name
             case age
             case price
+            case page
+            case groupLimit = "group_limit"
             case speed
             case mileage
             case isElectric = "is_electric"
+            case inStock = "in_stock"
             case empty
         }
     }
@@ -25,13 +31,16 @@ final class CreateURLQueryParamsTests: XCTestCase {
         do {
             let queryParams = try createURLQuery(forSchema: Car())
             print(queryParams)
-            XCTAssertEqual(queryParams.count, 6)
+            XCTAssertEqual(queryParams.count, 9)
             XCTAssertTrue(queryParams.contains(URLQueryItem(name: "name", value: "Fast")))
             XCTAssertTrue(queryParams.contains(URLQueryItem(name: "age", value: "20")))
             XCTAssertTrue(queryParams.contains(URLQueryItem(name: "price", value: "2000")))
+            XCTAssertTrue(queryParams.contains(URLQueryItem(name: "page", value: "1")))
+            XCTAssertTrue(queryParams.contains(URLQueryItem(name: "group_limit", value: "0")))
             XCTAssertTrue(queryParams.contains(URLQueryItem(name: "speed", value: "120.555")))
             XCTAssertTrue(queryParams.contains(URLQueryItem(name: "mileage", value: "120.5")))
             XCTAssertTrue(queryParams.contains(URLQueryItem(name: "is_electric", value: "true")))
+            XCTAssertTrue(queryParams.contains(URLQueryItem(name: "in_stock", value: "false")))
             XCTAssertFalse(queryParams.contains(URLQueryItem(name: "empty", value: "null")))
         } catch (let error) {
             print(error)

--- a/Tests/TypesenseTests/DocumentTests.swift
+++ b/Tests/TypesenseTests/DocumentTests.swift
@@ -172,7 +172,7 @@ final class DocumentTests: XCTestCase {
     }
 
     func testDocumentSearch() async {
-        let searchParams = SearchParameters(q: "stark", queryBy: "company_name", filterBy: "num_employees:>100", sortBy: "num_employees:desc")
+        let searchParams = SearchParameters(q: "*", queryBy: "company_name", page: 0, groupBy: "country", groupLimit: 1)
 
         do {
             try await createDocument()


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
https://github.com/typesense/typesense-swift/issues/41
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
