### PR TITLE
feat(search): add reranking and api key parameters to multi-search

### DIFF
--- a/Sources/Typesense/Models/MultiSearchCollectionParameters.swift
+++ b/Sources/Typesense/Models/MultiSearchCollectionParameters.swift
@@ -121,8 +121,12 @@ public struct MultiSearchCollectionParameters: Codable {
     public var facetReturnParent: String?
     /** The base64 encoded audio file in 16 khz 16-bit WAV format.  */
     public var voiceQuery: String?
+    /** Whether to rerank hybrid matches. */
+    public var rerankHybridMatches: Bool?
+    /** API key for the request. */
+    public var xTypesenseApiKey: String?
 
-    public init(q: String? = nil, queryBy: String? = nil, queryByWeights: String? = nil, textMatchType: String? = nil, _prefix: String? = nil, _infix: String? = nil, maxExtraPrefix: Int? = nil, maxExtraSuffix: Int? = nil, filterBy: String? = nil, sortBy: String? = nil, facetBy: String? = nil, maxFacetValues: Int? = nil, facetQuery: String? = nil, numTypos: String? = nil, page: Int? = nil, perPage: Int? = nil, limit: Int? = nil, offset: Int? = nil, groupBy: String? = nil, groupLimit: Int? = nil, groupMissingValues: Bool? = nil, includeFields: String? = nil, excludeFields: String? = nil, highlightFullFields: String? = nil, highlightAffixNumTokens: Int? = nil, highlightStartTag: String? = nil, highlightEndTag: String? = nil, snippetThreshold: Int? = nil, dropTokensThreshold: Int? = nil, typoTokensThreshold: Int? = nil, pinnedHits: String? = nil, hiddenHits: String? = nil, overrideTags: String? = nil, highlightFields: String? = nil, preSegmentedQuery: Bool? = nil, preset: String? = nil, enableOverrides: Bool? = nil, prioritizeExactMatch: Bool? = nil, prioritizeTokenPosition: Bool? = nil, prioritizeNumMatchingFields: Bool? = nil, enableTyposForNumericalTokens: Bool? = nil, exhaustiveSearch: Bool? = nil, searchCutoffMs: Int? = nil, useCache: Bool? = nil, cacheTtl: Int? = nil, minLen1typo: Int? = nil, minLen2typo: Int? = nil, vectorQuery: String? = nil, remoteEmbeddingTimeoutMs: Int? = nil, remoteEmbeddingNumTries: Int? = nil, collection: String? = nil, facetStrategy: String? = nil, stopwords: String? = nil, facetReturnParent: String? = nil, voiceQuery: String? = nil) {
+    public init(q: String? = nil, queryBy: String? = nil, queryByWeights: String? = nil, textMatchType: String? = nil, _prefix: String? = nil, _infix: String? = nil, maxExtraPrefix: Int? = nil, maxExtraSuffix: Int? = nil, filterBy: String? = nil, sortBy: String? = nil, facetBy: String? = nil, maxFacetValues: Int? = nil, facetQuery: String? = nil, numTypos: String? = nil, page: Int? = nil, perPage: Int? = nil, limit: Int? = nil, offset: Int? = nil, groupBy: String? = nil, groupLimit: Int? = nil, groupMissingValues: Bool? = nil, includeFields: String? = nil, excludeFields: String? = nil, highlightFullFields: String? = nil, highlightAffixNumTokens: Int? = nil, highlightStartTag: String? = nil, highlightEndTag: String? = nil, snippetThreshold: Int? = nil, dropTokensThreshold: Int? = nil, typoTokensThreshold: Int? = nil, pinnedHits: String? = nil, hiddenHits: String? = nil, overrideTags: String? = nil, highlightFields: String? = nil, preSegmentedQuery: Bool? = nil, preset: String? = nil, enableOverrides: Bool? = nil, prioritizeExactMatch: Bool? = nil, prioritizeTokenPosition: Bool? = nil, prioritizeNumMatchingFields: Bool? = nil, enableTyposForNumericalTokens: Bool? = nil, exhaustiveSearch: Bool? = nil, searchCutoffMs: Int? = nil, useCache: Bool? = nil, cacheTtl: Int? = nil, minLen1typo: Int? = nil, minLen2typo: Int? = nil, vectorQuery: String? = nil, remoteEmbeddingTimeoutMs: Int? = nil, remoteEmbeddingNumTries: Int? = nil, collection: String? = nil, facetStrategy: String? = nil, stopwords: String? = nil, facetReturnParent: String? = nil, voiceQuery: String? = nil, rerankHybridMatches: Bool? = nil, xTypesenseApiKey: String? = nil) {
         self.q = q
         self.queryBy = queryBy
         self.queryByWeights = queryByWeights
@@ -178,6 +182,8 @@ public struct MultiSearchCollectionParameters: Codable {
         self.stopwords = stopwords
         self.facetReturnParent = facetReturnParent
         self.voiceQuery = voiceQuery
+        self.rerankHybridMatches = rerankHybridMatches
+        self.xTypesenseApiKey = xTypesenseApiKey
     }
 
     public enum CodingKeys: String, CodingKey {
@@ -236,6 +242,8 @@ public struct MultiSearchCollectionParameters: Codable {
         case stopwords
         case facetReturnParent = "facet_return_parent"
         case voiceQuery = "voice_query"
+        case rerankHybridMatches = "rerank_hybrid_matches"
+        case xTypesenseApiKey = "x-typesense-api-key"
     }
 
 }

--- a/Sources/Typesense/Models/MultiSearchParameters.swift
+++ b/Sources/Typesense/Models/MultiSearchParameters.swift
@@ -126,8 +126,12 @@ public struct MultiSearchParameters: Codable {
     public var conversationModelId: String?
     /** The Id of a previous conversation to continue, this tells Typesense to include prior context when communicating with the LLM.  */
     public var conversationId: String?
+    /** Whether to rerank hybrid matches. */
+    public var rerankHybridMatches: Bool?
+    /** API key for the request. */
+    public var xTypesenseApiKey: String?
 
-    public init(q: String? = nil, queryBy: String? = nil, queryByWeights: String? = nil, textMatchType: String? = nil, _prefix: String? = nil, _infix: String? = nil, maxExtraPrefix: Int? = nil, maxExtraSuffix: Int? = nil, filterBy: String? = nil, sortBy: String? = nil, facetBy: String? = nil, maxFacetValues: Int? = nil, facetQuery: String? = nil, numTypos: String? = nil, page: Int? = nil, perPage: Int? = nil, limit: Int? = nil, offset: Int? = nil, groupBy: String? = nil, groupLimit: Int? = nil, groupMissingValues: Bool? = nil, includeFields: String? = nil, excludeFields: String? = nil, highlightFullFields: String? = nil, highlightAffixNumTokens: Int? = nil, highlightStartTag: String? = nil, highlightEndTag: String? = nil, snippetThreshold: Int? = nil, dropTokensThreshold: Int? = nil, typoTokensThreshold: Int? = nil, pinnedHits: String? = nil, hiddenHits: String? = nil, overrideTags: String? = nil, highlightFields: String? = nil, preSegmentedQuery: Bool? = nil, preset: String? = nil, enableOverrides: Bool? = nil, prioritizeExactMatch: Bool? = nil, prioritizeTokenPosition: Bool? = nil, prioritizeNumMatchingFields: Bool? = nil, enableTyposForNumericalTokens: Bool? = nil, exhaustiveSearch: Bool? = nil, searchCutoffMs: Int? = nil, useCache: Bool? = nil, cacheTtl: Int? = nil, minLen1typo: Int? = nil, minLen2typo: Int? = nil, vectorQuery: String? = nil, remoteEmbeddingTimeoutMs: Int? = nil, remoteEmbeddingNumTries: Int? = nil, facetStrategy: String? = nil, stopwords: String? = nil, facetReturnParent: String? = nil, voiceQuery: String? = nil, conversation: Bool? = nil, conversationModelId: String? = nil, conversationId: String? = nil) {
+    public init(q: String? = nil, queryBy: String? = nil, queryByWeights: String? = nil, textMatchType: String? = nil, _prefix: String? = nil, _infix: String? = nil, maxExtraPrefix: Int? = nil, maxExtraSuffix: Int? = nil, filterBy: String? = nil, sortBy: String? = nil, facetBy: String? = nil, maxFacetValues: Int? = nil, facetQuery: String? = nil, numTypos: String? = nil, page: Int? = nil, perPage: Int? = nil, limit: Int? = nil, offset: Int? = nil, groupBy: String? = nil, groupLimit: Int? = nil, groupMissingValues: Bool? = nil, includeFields: String? = nil, excludeFields: String? = nil, highlightFullFields: String? = nil, highlightAffixNumTokens: Int? = nil, highlightStartTag: String? = nil, highlightEndTag: String? = nil, snippetThreshold: Int? = nil, dropTokensThreshold: Int? = nil, typoTokensThreshold: Int? = nil, pinnedHits: String? = nil, hiddenHits: String? = nil, overrideTags: String? = nil, highlightFields: String? = nil, preSegmentedQuery: Bool? = nil, preset: String? = nil, enableOverrides: Bool? = nil, prioritizeExactMatch: Bool? = nil, prioritizeTokenPosition: Bool? = nil, prioritizeNumMatchingFields: Bool? = nil, enableTyposForNumericalTokens: Bool? = nil, exhaustiveSearch: Bool? = nil, searchCutoffMs: Int? = nil, useCache: Bool? = nil, cacheTtl: Int? = nil, minLen1typo: Int? = nil, minLen2typo: Int? = nil, vectorQuery: String? = nil, remoteEmbeddingTimeoutMs: Int? = nil, remoteEmbeddingNumTries: Int? = nil, facetStrategy: String? = nil, stopwords: String? = nil, facetReturnParent: String? = nil, voiceQuery: String? = nil, conversation: Bool? = nil, conversationModelId: String? = nil, conversationId: String? = nil, rerankHybridMatches: Bool? = nil, xTypesenseApiKey: String? = nil) {
         self.q = q
         self.queryBy = queryBy
         self.queryByWeights = queryByWeights
@@ -185,6 +189,8 @@ public struct MultiSearchParameters: Codable {
         self.conversation = conversation
         self.conversationModelId = conversationModelId
         self.conversationId = conversationId
+        self.rerankHybridMatches = rerankHybridMatches
+        self.xTypesenseApiKey = xTypesenseApiKey
     }
 
     public enum CodingKeys: String, CodingKey {
@@ -245,6 +251,8 @@ public struct MultiSearchParameters: Codable {
         case conversation
         case conversationModelId = "conversation_model_id"
         case conversationId = "conversation_id"
+        case rerankHybridMatches = "rerank_hybrid_matches"
+        case xTypesenseApiKey = "x-typesense-api-key"
     }
 
 }

--- a/Sources/Typesense/Models/MultiSearchSearchesParameter.swift
+++ b/Sources/Typesense/Models/MultiSearchSearchesParameter.swift
@@ -7,15 +7,75 @@
 
 import Foundation
 
-
-
 public struct MultiSearchSearchesParameter: Codable {
-
     public var searches: [MultiSearchCollectionParameters]
 
     public init(searches: [MultiSearchCollectionParameters]) {
         self.searches = searches
     }
+}
 
-
+extension MultiSearchSearchesParameter {
+    public init(searches: [MultiSearchParameters]) {
+        self.searches = searches.map { params in
+            var collectionParams = MultiSearchCollectionParameters()
+            collectionParams.q = params.q
+            collectionParams.queryBy = params.queryBy
+            collectionParams.queryByWeights = params.queryByWeights
+            collectionParams.textMatchType = params.textMatchType
+            collectionParams._prefix = params._prefix
+            collectionParams._infix = params._infix
+            collectionParams.maxExtraPrefix = params.maxExtraPrefix
+            collectionParams.maxExtraSuffix = params.maxExtraSuffix
+            collectionParams.filterBy = params.filterBy
+            collectionParams.sortBy = params.sortBy
+            collectionParams.facetBy = params.facetBy
+            collectionParams.maxFacetValues = params.maxFacetValues
+            collectionParams.facetQuery = params.facetQuery
+            collectionParams.numTypos = params.numTypos
+            collectionParams.page = params.page
+            collectionParams.perPage = params.perPage
+            collectionParams.limit = params.limit
+            collectionParams.offset = params.offset
+            collectionParams.groupBy = params.groupBy
+            collectionParams.groupLimit = params.groupLimit
+            collectionParams.groupMissingValues = params.groupMissingValues
+            collectionParams.includeFields = params.includeFields
+            collectionParams.excludeFields = params.excludeFields
+            collectionParams.highlightFullFields = params.highlightFullFields
+            collectionParams.highlightAffixNumTokens = params.highlightAffixNumTokens
+            collectionParams.highlightStartTag = params.highlightStartTag
+            collectionParams.highlightEndTag = params.highlightEndTag
+            collectionParams.snippetThreshold = params.snippetThreshold
+            collectionParams.dropTokensThreshold = params.dropTokensThreshold
+            collectionParams.typoTokensThreshold = params.typoTokensThreshold
+            collectionParams.pinnedHits = params.pinnedHits
+            collectionParams.hiddenHits = params.hiddenHits
+            collectionParams.overrideTags = params.overrideTags
+            collectionParams.highlightFields = params.highlightFields
+            collectionParams.preSegmentedQuery = params.preSegmentedQuery
+            collectionParams.preset = params.preset
+            collectionParams.enableOverrides = params.enableOverrides
+            collectionParams.prioritizeExactMatch = params.prioritizeExactMatch
+            collectionParams.prioritizeTokenPosition = params.prioritizeTokenPosition
+            collectionParams.prioritizeNumMatchingFields = params.prioritizeNumMatchingFields
+            collectionParams.enableTyposForNumericalTokens = params.enableTyposForNumericalTokens
+            collectionParams.exhaustiveSearch = params.exhaustiveSearch
+            collectionParams.searchCutoffMs = params.searchCutoffMs
+            collectionParams.useCache = params.useCache
+            collectionParams.cacheTtl = params.cacheTtl
+            collectionParams.minLen1typo = params.minLen1typo
+            collectionParams.minLen2typo = params.minLen2typo
+            collectionParams.vectorQuery = params.vectorQuery
+            collectionParams.remoteEmbeddingTimeoutMs = params.remoteEmbeddingTimeoutMs
+            collectionParams.remoteEmbeddingNumTries = params.remoteEmbeddingNumTries
+            collectionParams.facetStrategy = params.facetStrategy
+            collectionParams.stopwords = params.stopwords
+            collectionParams.facetReturnParent = params.facetReturnParent
+            collectionParams.voiceQuery = params.voiceQuery
+            collectionParams.rerankHybridMatches = params.rerankHybridMatches
+            collectionParams.xTypesenseApiKey = params.xTypesenseApiKey
+            return collectionParams
+        }
+    }
 }


### PR DESCRIPTION
## Change Summary
- Add `rerankHybridMatches` boolean parameter for reranking hybrid matches
- Add `xTypesenseApiKey` parameter to support per-request API keys
- Update initializers in both parameter models to include new fields
- Extend `MultiSearchSearchesParameter` to properly map between parameter types


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
