### PR TITLE
fix CI: qemu is required to emulate x86_64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install and start dependencies
         run: |
           brew install docker
+          brew install qemu
           brew install colima
           # https://github.com/abiosoft/colima/issues/424#issuecomment-1335912905
           colima delete
@@ -32,7 +33,7 @@ jobs:
           mkdir $(pwd)/typesense-data
           docker run -p 8108:8108 \
             -d \
-            -v$(pwd)/typesense-data:/data typesense/typesense:27.0 \
+            -v$(pwd)/typesense-data:/data typesense/typesense:28.0 \
             --data-dir /data \
             --api-key=xyz \
             --enable-cors


### PR DESCRIPTION
Also updated Typesense to 28.0

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
